### PR TITLE
Fix attack bugs

### DIFF
--- a/arena.gd
+++ b/arena.gd
@@ -1,8 +1,12 @@
 extends Node3D
 
 @export var arrow_scene : PackedScene
-
+ 
 func shoot_arrow(shot_power: float, mouse_pos: Vector2, player_pos: Vector3):
 	var arrow : Node = arrow_scene.instantiate()
 	add_child(arrow)
 	arrow.shoot(shot_power, mouse_pos, player_pos)
+
+
+func _on_player_attack_1_finished() -> void:
+	$Enemy.attack1_finished()

--- a/arena.tscn
+++ b/arena.tscn
@@ -81,7 +81,8 @@ points = PackedVector2Array(-160, -85, -160, 85, 160, 85, 160, -85)
 closed = true
 width = 3.0
 
-[node name="Area3D" parent="." instance=ExtResource("7_pbtuc")]
+[node name="Enemy" parent="." instance=ExtResource("7_pbtuc")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1, 0)
 
+[connection signal="attack1_finished" from="Player" to="." method="_on_player_attack_1_finished"]
 [connection signal="shoot" from="Player" to="." method="shoot_arrow"]

--- a/arrow.gd
+++ b/arrow.gd
@@ -10,8 +10,15 @@ var speed_intercept : float
 var move_direction : Vector3 = Vector3.ZERO
 var speed : float
 
+var power : float = 1
+
+func _ready() -> void:
+	find_speed_equation()
+
+
 func _physics_process(delta: float) -> void:
 	position += move_direction * speed * delta
+
 
 func shoot(shot_power: float, mouse_pos: Vector2, player_pos: Vector3) -> void:
 	# get the mouse pos based on the center of the screen
@@ -26,11 +33,12 @@ func shoot(shot_power: float, mouse_pos: Vector2, player_pos: Vector3) -> void:
 	move_direction.x = new_mouse_pos.normalized().x
 	move_direction.z = -new_mouse_pos.normalized().y
 	
-	if shot_power < 0.1:
-		shot_power = 0.1
-	find_speed_equation()
+	power = shot_power
+	if power < 0.1:
+		power = 0.1
 	speed = speed_slope * shot_power + speed_intercept
 	position = player_pos
+
 
 func find_speed_equation() -> void:
 	speed_slope = (MAX_SPEED - MIN_SPEED) / 0.9

--- a/arrow.tscn
+++ b/arrow.tscn
@@ -6,7 +6,7 @@
 [sub_resource type="BoxShape3D" id="BoxShape3D_l5ahi"]
 size = Vector3(0.72, 0.2, 0.2)
 
-[node name="Arrow" type="Area3D"]
+[node name="Arrow" type="Area3D" groups=["Arrows"]]
 script = ExtResource("1_2ndhl")
 
 [node name="Sprite3D" type="Sprite3D" parent="."]

--- a/player.gd
+++ b/player.gd
@@ -1,6 +1,7 @@
 extends CharacterBody3D
 
 signal shoot(shot_power, mouse_pos, spawn_pos)
+signal attack1_finished()
 
 @export var WALK_SPEED : float = 10.0
 @export var ACCELERATION_SPEED : float = 30.0
@@ -104,6 +105,7 @@ func _on_animated_sprite_3d_animation_finished() -> void:
 	match $AnimatedSprite3D.animation:
 		"attack1":
 			attack1_hitboxes[$AnimatedSprite3D.frame].disabled = true
+			attack1_finished.emit()
 			attack = 0
 			$AnimatedSprite3D.play("idle")
 		
@@ -122,7 +124,6 @@ func _on_animated_sprite_3d_frame_changed() -> void:
 	if $AnimatedSprite3D.animation != "attack1":
 		return
 	
-	print(attack1_hitboxes[$AnimatedSprite3D.frame])
 	attack1_hitboxes[$AnimatedSprite3D.frame].disabled = false
 	
 	if $AnimatedSprite3D.frame == 0:

--- a/player.tscn
+++ b/player.tscn
@@ -345,6 +345,7 @@ script = ExtResource("1_p6a14")
 
 [node name="PlayerCollision" type="CollisionShape3D" parent="."]
 transform = Transform3D(0.375, 0, 0, 0, 0.375, 0, 0, 0, 0.375, -0.00127029, 0.0873618, -0.131)
+visible = false
 shape = SubResource("BoxShape3D_hesjb")
 
 [node name="AnimatedSprite3D" type="AnimatedSprite3D" parent="."]

--- a/test_enemy.gd
+++ b/test_enemy.gd
@@ -1,8 +1,9 @@
 extends Area3D
 
+var hit_by_attack1 : bool = false
 
-func _on_body_entered(body: Node3D) -> void:
-	print(body.name)
+func attack1_finished() -> void:
+	hit_by_attack1 = false
 
 
 func _on_body_shape_entered(_body_rid: RID, body: Node3D, body_shape_index: int, _local_shape_index: int) -> void:
@@ -14,13 +15,14 @@ func _on_body_shape_entered(_body_rid: RID, body: Node3D, body_shape_index: int,
 	var body_shape_owner = body.shape_find_owner(body_shape_index)
 	var body_shape_node = body.shape_owner_get_owner(body_shape_owner)
 	
-	if body_shape_node.is_in_group("Attack1 Hitboxes"):
-		print("Hit by: " + body_shape_node.name)
+	if body_shape_node.is_in_group("Attack1 Hitboxes") && hit_by_attack1 == false:
+		hit_by_attack1 = true
+		print("Hit by Attack1")
 
 
 func _on_area_shape_entered(_area_rid: RID, area: Area3D, area_shape_index: int, _local_shape_index: int) -> void:
 	var area_shape_owner = area.shape_find_owner(area_shape_index)
-	var area_shape_node = area.shape_owner_get_owner(area_shape_owner)
+	var _area_shape_node = area.shape_owner_get_owner(area_shape_owner)
 	
-	print(area.name)
-	print(area_shape_node.name)
+	if area.is_in_group("Arrows"):
+		print("Hit by Arrow with power " + str(area.power))


### PR DESCRIPTION
When using `attack1`, each hitbox would register as its own hit. I made it so that each attack would only register as 1 hit. I also made it output that it was hit by an arrow and output the power of the arrow